### PR TITLE
Added option to start line numbering at one instead of zero.

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -6,6 +6,7 @@ class LineNumberView
     @subscriptions = new CompositeDisposable()
     @editorView = atom.views.getView(@editor)
     @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
+    @startAtOne = atom.config.get('relative-numbers.startAtOne')
 
     @gutter = @editor.addGutter
       name: 'relative-numbers'
@@ -23,6 +24,11 @@ class LineNumberView
     # Subscribe to when the true number on current line config is modified.
     @subscriptions.add atom.config.onDidChange 'relative-numbers.trueNumberCurrentLine', =>
       @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
+      @_update()
+
+    # Subscribe to when the start at one config option is modified
+    @subscriptions.add atom.config.onDidChange 'relative-numbers.trueNumberCurrentLine', =>
+      @startAtOne = atom.config.get('relative-numbers.startAtOne')
       @_update()
 
     # Dispose the subscriptions when the editor is destroyed.
@@ -46,11 +52,15 @@ class LineNumberView
     totalLines = @editor.getLineCount()
     currentLineNumber = Number(@editor.getCursorBufferPosition().row) + 1
     lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-number')
+    offset = 0
+
+    if @startAtOne
+      offset = 1
 
     for lineNumberElement in lineNumberElements
       row = Number(lineNumberElement.getAttribute('data-buffer-row'))
       absolute = row + 1
-      relative = (Math.abs(currentLineNumber - absolute))
+      relative = (Math.abs(currentLineNumber - absolute) + offset)
       relativeClass = 'relative'
       if @trueNumberCurrentLine and relative == 0
         relative = currentLineNumber

--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -8,9 +8,14 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Show the true number on the current line'
+    startAtOne:
+      type: 'boolean'
+      default: false
+      description: 'Start relative line numbering at one'
 
   configDefaults:
     trueNumberCurrentLine: true
+    startAtOne: false
 
   subscriptions: null
 


### PR DESCRIPTION
Hey there! So I am quite dumb. Sometimes I am making vast quantities of edits in files with commands like "<4<" in vim-mode that are numerically based on the current line so when the relative line number is 0 based like normal I have to mentally think about it otherwise I'll indent one more line than desired. So I thought it would be nice to have an option to change the index to be 1-based to give accuracy to those kinds of commands if desired. By default it should be off. It appears to be working so far in my use of it so it's ready for your review & evaluation.

Also: I am just starting to get my feet wet in Atom development and was looking into adding a config option to always show the absolute numbers by applying different rules in the styles but it appears after some research that loading a coffeescript setting into the styles is fairly non-trivial. Is that why it was recommended to just apply those styles to show absolute numbers in our own stylesheets?