### PR TITLE
Created Setting to Show Absolute Numbers

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -45,6 +45,7 @@ class LineNumberView
       @observer.disconnect()
 
     @_update()
+    @_updateAbsoluteNumbers()
 
   destroy: () ->
     @subscriptions.dispose()

--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -8,6 +8,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Show the true number on the current line'
+    showAbsoluteNumbers:
+      type: 'boolean'
+      default: false
+      description: 'Show absolute line numbers too?'
     startAtOne:
       type: 'boolean'
       default: false
@@ -15,6 +19,7 @@ module.exports =
 
   configDefaults:
     trueNumberCurrentLine: true
+    showAbsoluteNumbers: false
     startAtOne: false
 
   subscriptions: null

--- a/styles/main.less
+++ b/styles/main.less
@@ -34,14 +34,13 @@ atom-text-editor.vim-mode-plus.insert-mode::shadow {
 // Show absolute
 atom-text-editor::shadow .show-absolute {
   text-align: left;
-  color: fade(@text-color-selected, 50%);
-
+  color: fade(@syntax-gutter-text-color, 50%);
   .absolute {
     display: inline;
     margin-right: 1em;
   }
   .relative {
     display: inline !important;
-    color: fade(@text-color-selected, 100%);
+    color: fade(@syntax-gutter-text-color, 100%);
   }
 }

--- a/styles/main.less
+++ b/styles/main.less
@@ -30,3 +30,18 @@ atom-text-editor.vim-mode-plus.insert-mode::shadow {
     display: none
   }
 }
+
+// Show absolute
+atom-text-editor::shadow .show-absolute {
+  text-align: left;
+  color: fade(@text-color-selected, 50%);
+
+  .absolute {
+    display: inline;
+    margin-right: 1em;
+  }
+  .relative {
+    display: inline !important;
+    color: fade(@text-color-selected, 100%);
+  }
+}


### PR DESCRIPTION
Hey again, so after talking to some people in the Atom Slack the recommended way to have a config option affect styles was simply to add\remove a class. So with some minor edits a "Show absolute line numbers" setting was created to show the absolute numbers that are hidden by this plugin by default. 

I think it's kind of convenient to have a setting as it's not so much a personalized customization as I imagine is the intent behind the custom stylesheets in atom but a pretty specific selector & styles to achieve a consistent, desired effect. It can still be customized further in a user's styles but I think it's valuable to supply the core basics for that functionality.