### PR TITLE
fix #10

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -113,7 +113,8 @@ class LineNumberView
       relative = Math.abs(currentLineNumber - absolute)
       relativeClass = 'relative'
       if @trueNumberCurrentLine and relative == 0
-        relative = currentLineNumber - 1
+        relative = currentLineNumber
+        relative-- if @startAtOne
         relativeClass += ' current-line'
       # Apply offset last thing before rendering
       relative += offset


### PR DESCRIPTION
When "Start At One" is not set, the "True Number" showed one less than the actual line number (starting with "0" on line 1).