### PR TITLE
[FIX] exit while editor has been destroyed

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -86,7 +86,15 @@ class LineNumberView
 
   _updateSync: () =>
     totalLines = @editor.getLineCount()
-    currentLineNumber = @editor.getCursorScreenPosition().row
+    hasError = false;
+    try
+      currentLineNumber = @editor.getCursorScreenPosition().row
+    catch
+      # if editor has been destroyed, it will throw error
+      hasError = true;
+
+    if hasError
+      return
 
     # Check if selection ends with newline
     # (The selection ends with new line because of the package vim-mode when


### PR DESCRIPTION
Fixed #13

#13 often happing while open a large file and close it quickly, then the text editor will throw error.
Just ignore that error and exit maybe ok