### PR TITLE
Optionally count soft-wrap lines, default is existing behavior

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -8,6 +8,7 @@ class LineNumberView
     @trueNumberCurrentLine = atom.config.get('relative-numbers.trueNumberCurrentLine')
     @showAbsoluteNumbers = atom.config.get('relative-numbers.showAbsoluteNumbers')
     @startAtOne = atom.config.get('relative-numbers.startAtOne')
+    @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
 
     @lineNumberGutterView = atom.views.getView(@editor.gutterWithName('line-number'))
 
@@ -43,6 +44,12 @@ class LineNumberView
     @subscriptions.add atom.config.onDidChange 'relative-numbers.startAtOne', =>
       @startAtOne = atom.config.get('relative-numbers.startAtOne')
       @_update()
+
+    # Subscribe to when the start at one config option is modified
+    @subscriptions.add atom.config.onDidChange 'relative-numbers.softWrapsCount', =>
+      @softWrapsCount = atom.config.get('relative-numbers.softWrapsCount')
+      @_update()
+
 
     # Dispose the subscriptions when the editor is destroyed.
     @subscriptions.add @editor.onDidDestroy =>
@@ -89,7 +96,9 @@ class LineNumberView
       return
 
     totalLines = @editor.getLineCount()
-    currentLineNumber = @editor.getCursorScreenPosition().row
+    currentLineNumber = if @softWrapsCount then @editor.getCursorScreenPosition().row else @editor.getCursorBufferPosition().row
+
+    console.log(currentLineNumber)
 
     # Check if selection ends with newline
     # (The selection ends with new line because of the package vim-mode when
@@ -101,10 +110,11 @@ class LineNumberView
 
     lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-number')
     offset = if @startAtOne then 1 else 0
+    counting_attribute = if @softWrapsCount then 'data-screen-row' else 'data-buffer-row'
 
     for lineNumberElement in lineNumberElements
       # "|| 0" is used given data-screen-row is undefined for the first row
-      row = Number(lineNumberElement.getAttribute('data-screen-row')) || 0
+      row = Number(lineNumberElement.getAttribute(counting_attribute)) || 0
 
       absolute = row + 1
 

--- a/lib/relative-numbers.coffee
+++ b/lib/relative-numbers.coffee
@@ -16,6 +16,10 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Start relative line numbering at one'
+    softWrapsCount:
+      type: 'boolean'
+      default: true
+      description: 'Do soft-wrapped lines count? (No in vim-mode-plus, yes in vim-mode)'
 
   configDefaults:
     trueNumberCurrentLine: true


### PR DESCRIPTION
It looks like `vim-mode` [is getting deprecated](https://github.com/atom/vim-mode) in favor of `vim-mode-plus`  One weird difference is that `vim-mode-plus` doesn't count soft-wrap lines in repeat actions (e.g., `d9j`) but `vim-mode` did.

I made it a config option in this package, and left the default as the existing behavior (count 'em).  That should help people make the jump at their leisure.

This might also close out [Issue 15](https://github.com/justmoon/relative-numbers/issues/15)?

Thanks for an amazing package, it makes my life easier dozens of times a day.

