### PR TITLE
📝make compatible with atom-beta10 and vim-mode-plus

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -42,3 +42,8 @@ atom-text-editor::shadow .show-absolute {
     display: inline !important;
   }
 }
+
+// Make compatible with atom-beta and vim-mode-plus  
+atom-text-editor .gutter .line-number .absolute{
+  display: none
+}


### PR DESCRIPTION
for some reason this package doesn't work perfectly with the new version of `atom-beta-10` and [vim-mode-plus](https://github.com/t9md/atom-vim-mode-plus)(show absolute line numbers on the side), so I added one styling line to hide the extra numbers.

![2017-01-07 00 50 49](https://cloud.githubusercontent.com/assets/19645990/21739783/6c3bac8a-d473-11e6-8cf4-20a302572425.gif)

atom -v:
* Atom    : 1.13.0-beta10

vim-mode-plus:
* 0.78.0
