### PR TITLE
Atom v1.13/remove deprecated styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relative-numbers",
   "main": "./lib/relative-numbers",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Relative line numbers for Atom",
   "repository": "https://github.com/justmoon/relative-numbers",
   "license": "MIT",

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .relative.current-line {
     // Add some color to make the current line stand out.
     color: @text-color-info
@@ -20,8 +20,8 @@ atom-text-editor::shadow {
 }
 
 // In insert mode, line numbers should return to normal
-atom-text-editor.vim-mode.insert-mode::shadow,
-atom-text-editor.vim-mode-plus.insert-mode::shadow {
+atom-text-editor.editor.vim-mode.insert-mode,
+atom-text-editor.editor.vim-mode-plus.insert-mode {
   .absolute {
     display: inline
   }
@@ -31,7 +31,7 @@ atom-text-editor.vim-mode-plus.insert-mode::shadow {
 }
 
 // Show absolute config option
-atom-text-editor::shadow .show-absolute {
+atom-text-editor.editor .show-absolute {
   // text-align: left;
   .absolute {
     display: inline;


### PR DESCRIPTION
Fixes https://github.com/justmoon/relative-numbers/issues/24

Atom has updated to `v1.13.0` and introduced a breaking change: no more shadow dom.
The selector using shadow dom need to be updated. Atom tries to fix this with an automatic rewrite but it doesn't work since the styles of `relative-numbers` package do not touch the `.syntax--` prefixed elements.

This PR updated styles accordingly. I also bumped the version to `0.7.0` but I can remove this commit if you wish to do it yourself.
