### PR TITLE
Fix gutter line-numbers selection

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -106,7 +106,7 @@ class LineNumberView
     else
       currentLineNumber = currentLineNumber + 1
 
-    lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-number')
+    lineNumberElements = @editorView.rootElement?.querySelectorAll('.line-numbers .line-number')
     offset = if @startAtOne then 1 else 0
     counting_attribute = if @softWrapsCount then 'data-screen-row' else 'data-buffer-row'
 


### PR DESCRIPTION
Only select elements with the class `line-number` that exist inside the line-numbers gutter.
An example of another gutter is `linter-ui-default`s gutter, which has the class `custom-decorations`.

Fixes #34 