### PR TITLE
Fix absolute with collapsed blocks

### DIFF
--- a/lib/line-number-view.coffee
+++ b/lib/line-number-view.coffee
@@ -99,9 +99,11 @@ class LineNumberView
       # "|| 0" is used given data-screen-row is undefined for the first row
       row = Number(lineNumberElement.getAttribute(counting_attribute)) || 0
 
-      absolute = row + 1
+      absolute_number_for_relative = row + 1
 
-      relative = Math.abs(currentLineNumber - absolute)
+      absolute = Number(lineNumberElement.getAttribute('data-buffer-row')) || 0
+
+      relative = Math.abs(currentLineNumber - absolute_number_for_relative)
       relativeClass = 'relative'
 
       if @trueNumberCurrentLine and relative == 0


### PR DESCRIPTION
fixes #33

If ``Soft wraps count`` was enabled the absolute numbers were the
``'data-screen-row'`` before. This was unexpected behaviour and doesn't
fit to atom's default behaviour. Now the ``absolute`` row number used
for the display is always fetched using ``'data-buffer-row'`` while the
absolute row number used for calculating ``relative`` depends on the
``softWrapsCount`` setting.