### PR TITLE
fix compatibility with minimap

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-atom-text-editor.editor {
+atom-text-editor.editor .line-numbers {
   .relative.current-line {
     // Add some color to make the current line stand out.
     color: @text-color-info


### PR DESCRIPTION
This PR scopes `.absolute` styles for this package so that it doesn't clobber other uses of the class.

Fixes a compatibility issue with minimap, where this plugin break's minimap's `absolute-mode` feature